### PR TITLE
[site] Add experience quest log page

### DIFF
--- a/public/experience.json
+++ b/public/experience.json
@@ -1,0 +1,37 @@
+{
+  "mainQuest": {
+    "title": "Forge the Ultimate Portfolio",
+    "startDate": "2023-01-01",
+    "endDate": null,
+    "description": "A never-ending mission to craft the perfect portfolio using modern web technologies and share experiments with the world.",
+    "link": "https://github.com/Demential98",
+    "image": "https://placehold.co/600x400?text=Main+Quest"
+  },
+  "sideQuests": [
+    {
+      "title": "DIY NAS Build",
+      "startDate": "2023-05-01",
+      "endDate": "2023-08-15",
+      "description": "Built a personal NAS using a Raspberry Pi and custom software for backups and media streaming.",
+      "link": "https://github.com/Demential98/diy-nas",
+      "image": "https://placehold.co/600x400?text=NAS"
+    },
+    {
+      "title": "Retro Console Mod",
+      "startDate": "2024-02-01",
+      "endDate": null,
+      "description": "Modding an old handheld console with a new screen, rechargeable battery, and custom software.",
+      "link": "https://github.com/Demential98/retro-console",
+      "image": null
+    },
+    {
+      "title": "Portfolio V2",
+      "startDate": "2024-09-01",
+      "endDate": null,
+      "description": "Rewriting my portfolio with React, Vite, and Tailwind to showcase projects and experiments.",
+      "link": "https://github.com/Demential98/Demential98.github.io",
+      "image": "https://placehold.co/600x400?text=Portfolio"
+    }
+  ]
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,8 +135,24 @@ function App() {
               speed="5s"
             >
               <Link to="/about" >
-                <ShinyText 
+                <ShinyText
                   text={t('about')}
+                  disabled={false}
+                  speed={3}
+                  className='custom-class'
+                />
+                </Link>
+            </StarBorder>
+            <StarBorder
+              as="div"
+              className="custom-class"
+              color={theme === 'dark' ? 'cyan' : '#020617'}
+              thickness="2"
+              speed="5s"
+            >
+              <Link to="/experience" >
+                <ShinyText
+                  text={t('experience')}
                   disabled={false}
                   speed={3}
                   className='custom-class'

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -4,6 +4,7 @@ import { AnimatePresence } from 'framer-motion';
 
 import Home from './pages/Home';
 import About from './pages/About';
+import Experience from './pages/Experience';
 import NotFound from './pages/NotFound';
 import PageWrapper from './components/PageWrapper';
 
@@ -18,6 +19,7 @@ export default function AppRoutes() {
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<PageWrapper><Home /></PageWrapper>} />
         <Route path="/about" element={<PageWrapper><About /></PageWrapper>} />
+        <Route path="/experience" element={<PageWrapper><Experience /></PageWrapper>} />
         <Route path="/test" element={<PageWrapper><Test /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,5 +5,12 @@
   "home": "Home",
   "about": "About",
   "not_found_message": "These aren't the droids you're looking for.",
-  "go_home": "Go back home"
+  "go_home": "Go back home",
+  "experience": "Experience",
+  "main_quest": "Main Quest",
+  "side_quests": "Side Quests",
+  "close": "Close",
+  "visit": "Visit",
+  "present": "Present",
+  "loading": "Loading..."
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -5,5 +5,12 @@
   "home": "Home",
   "about": "Informazioni",
   "not_found_message": "Questi non sono i droidi che state cercando",
-  "go_home": "Torna alla home"
+  "go_home": "Torna alla home",
+  "experience": "Esperienza",
+  "main_quest": "Missione Principale",
+  "side_quests": "Missioni Secondarie",
+  "close": "Chiudi",
+  "visit": "Visita",
+  "present": "Presente",
+  "loading": "Caricamento..."
 }

--- a/src/pages/Experience.jsx
+++ b/src/pages/Experience.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function QuestCard({ quest, onClick }) {
+  const { t } = useTranslation();
+  const period = `${quest.startDate} - ${quest.endDate || t('present')}`;
+  const snippet =
+    quest.description.length > 80
+      ? `${quest.description.slice(0, 80)}...`
+      : quest.description;
+
+  return (
+    <div
+      onClick={onClick}
+      className="border rounded p-4 cursor-pointer hover:shadow-md transition-shadow"
+    >
+      <h3 className="text-xl font-semibold">{quest.title}</h3>
+      <p className="text-sm text-gray-500">{period}</p>
+      <p className="mt-2 text-sm">{snippet}</p>
+    </div>
+  );
+}
+
+function QuestModal({ quest, onClose }) {
+  const { t } = useTranslation();
+  const period = `${quest.startDate} - ${quest.endDate || t('present')}`;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-[var(--bg-color)] text-[var(--text-color)] p-6 rounded max-w-lg w-full max-h-[90vh] overflow-y-auto">
+        <button onClick={onClose} className="mb-4 underline">
+          {t('close')}
+        </button>
+        <h2 className="text-2xl font-bold mb-2">{quest.title}</h2>
+        <p className="text-sm text-gray-500 mb-4">{period}</p>
+        {quest.image && (
+          <img src={quest.image} alt={quest.title} className="mb-4 rounded" />
+        )}
+        <p className="mb-4 whitespace-pre-line">{quest.description}</p>
+        {quest.link && (
+          <a
+            href={quest.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline"
+          >
+            {t('visit')}
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Experience() {
+  const { t } = useTranslation();
+  const [data, setData] = useState(null);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    fetch('/experience.json')
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+  }, []);
+
+  if (!data) return <div className="p-6">{t('loading')}</div>;
+
+  return (
+    <div className="p-6 overflow-y-auto">
+      <h1 className="text-3xl mb-6">{t('experience')}</h1>
+
+      <section className="mb-8">
+        <h2 className="text-2xl mb-4">{t('main_quest')}</h2>
+        <QuestCard quest={data.mainQuest} onClick={() => setSelected(data.mainQuest)} />
+      </section>
+
+      <section>
+        <h2 className="text-2xl mb-4">{t('side_quests')}</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          {data.sideQuests.map((q, idx) => (
+            <QuestCard key={idx} quest={q} onClick={() => setSelected(q)} />
+          ))}
+        </div>
+      </section>
+
+      {selected && <QuestModal quest={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add JSON-driven experience quest log
- wire up Experience page and navigation
- provide translations for new page

## Testing
- `npm run lint` *(fails: lastFontSize unused, textAlign unused, Component unused, t unused, __dirname is not defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1add86c832192e889a08640396b