### PR TITLE
[site] Add experience page with dynamic quests

### DIFF
--- a/public/data/experience.json
+++ b/public/data/experience.json
@@ -1,0 +1,34 @@
+{
+  "quests": [
+    {
+      "id": "portfolio",
+      "type": "main",
+      "title": "Launch Portfolio Site",
+      "start": "2024-01",
+      "end": "2024-04",
+      "description": "Built and deployed my personal portfolio using React, Vite and Tailwind.",
+      "url": "https://github.com/Demential98/Demential98.github.io",
+      "image": "https://placehold.co/600x400?text=Portfolio"
+    },
+    {
+      "id": "diy-nas",
+      "type": "side",
+      "title": "DIY NAS",
+      "start": "2023-05",
+      "end": "2023-07",
+      "description": "Assembled a home server to store my files and media.",
+      "url": "https://github.com/Demential98/diy-nas",
+      "image": "https://placehold.co/600x400?text=NAS"
+    },
+    {
+      "id": "printer-mods",
+      "type": "side",
+      "title": "3D Printer Mods",
+      "start": "2022-02",
+      "end": "2022-04",
+      "description": "Upgraded my 3D printer with silent drivers and auto bed leveling.",
+      "url": "https://example.com/3d-printer",
+      "image": null
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,8 +135,24 @@ function App() {
               speed="5s"
             >
               <Link to="/about" >
-                <ShinyText 
+                <ShinyText
                   text={t('about')}
+                  disabled={false}
+                  speed={3}
+                  className='custom-class'
+                />
+                </Link>
+            </StarBorder>
+            <StarBorder
+              as="div"
+              className="custom-class"
+              color={theme === 'dark' ? 'cyan' : '#020617'}
+              thickness="2"
+              speed="5s"
+            >
+              <Link to="/experience" >
+                <ShinyText
+                  text={t('experience')}
                   disabled={false}
                   speed={3}
                   className='custom-class'

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -4,6 +4,7 @@ import { AnimatePresence } from 'framer-motion';
 
 import Home from './pages/Home';
 import About from './pages/About';
+import Experience from './pages/Experience';
 import NotFound from './pages/NotFound';
 import PageWrapper from './components/PageWrapper';
 
@@ -18,6 +19,7 @@ export default function AppRoutes() {
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<PageWrapper><Home /></PageWrapper>} />
         <Route path="/about" element={<PageWrapper><About /></PageWrapper>} />
+        <Route path="/experience" element={<PageWrapper><Experience /></PageWrapper>} />
         <Route path="/test" element={<PageWrapper><Test /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>

--- a/src/components/FuzzyText.jsx
+++ b/src/components/FuzzyText.jsx
@@ -23,8 +23,6 @@ const FuzzyText = ({
   const canvas = canvasRef.current;
   if (!canvas) return;
 
-  let lastColor = "";
-  let lastFontSize = "";
 
   const drawText = async () => {
     if (document.fonts?.ready) await document.fonts.ready;
@@ -183,8 +181,6 @@ const FuzzyText = ({
     };
 
     canvas.cleanupFuzzyText = cleanup;
-    lastColor = resolvedColor;
-    lastFontSize = fontSizeStr;
   };
 
   drawText();

--- a/src/components/SplitText/SplitText.jsx
+++ b/src/components/SplitText/SplitText.jsx
@@ -6,7 +6,6 @@ const SplitText = ({
   className = '',
   delay = 0.05,
   triggerOnScroll = true,
-  textAlign = 'left',
 }) => {
   const containerRef = useRef(null);
   const [active, setActive] = useState(!triggerOnScroll);

--- a/src/components/StarBorder/StarBorder.jsx
+++ b/src/components/StarBorder/StarBorder.jsx
@@ -1,7 +1,7 @@
 import "./StarBorder.css";
 
 const StarBorder = ({
-  as: Component = "button",
+  as = "button",
   className = "",
   color = "white",
   speed = "6s",
@@ -9,9 +9,10 @@ const StarBorder = ({
   children,
   ...rest
 }) => {
+  const Tag = as;
   return (
-    <Component 
-      className={`star-border-container ${className}`} 
+    <Tag
+      className={`star-border-container ${className}`}
       style={{
         padding: `${thickness}px 0`,
         ...rest.style
@@ -33,7 +34,7 @@ const StarBorder = ({
         }}
       ></div>
       <div className="inner-content">{children}</div>
-    </Component>
+    </Tag>
   );
 };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,11 @@
   "light_mode": "Switch to Light Mode",
   "home": "Home",
   "about": "About",
+  "experience": "Experience",
   "not_found_message": "These aren't the droids you're looking for.",
-  "go_home": "Go back home"
+  "go_home": "Go back home",
+  "experience_title": "Experience",
+  "experience_main_quests": "Main Quest",
+  "experience_side_quests": "Side Quests",
+  "experience_view_more": "View more"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -4,6 +4,11 @@
   "light_mode": "Passa alla modalità chiara",
   "home": "Home",
   "about": "Informazioni",
+  "experience": "Esperienza",
   "not_found_message": "Questi non sono i droidi che state cercando",
-  "go_home": "Torna alla home"
+  "go_home": "Torna alla home",
+  "experience_title": "Esperienza",
+  "experience_main_quests": "Missione principale",
+  "experience_side_quests": "Missioni secondarie",
+  "experience_view_more": "Scopri di più"
 }

--- a/src/pages/Experience.jsx
+++ b/src/pages/Experience.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function QuestCard({ quest, onClick }) {
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer bg-neutral-800 rounded p-4 hover:bg-neutral-700 transition-colors flex flex-col"
+    >
+      {quest.image && (
+        <img
+          src={quest.image}
+          alt=""
+          className="mb-2 h-40 w-full object-cover rounded"
+        />
+      )}
+      <h3 className="text-lg font-bold mb-1">{quest.title}</h3>
+      <p className="text-sm text-neutral-400">
+        {quest.start} – {quest.end}
+      </p>
+    </div>
+  );
+}
+
+function QuestModal({ quest, onClose, t }) {
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-neutral-900 p-6 rounded max-w-lg w-full relative">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-2xl leading-none"
+        >
+          ×
+        </button>
+        <h3 className="text-xl font-bold mb-2">{quest.title}</h3>
+        <p className="text-sm mb-4 text-neutral-400">
+          {quest.start} – {quest.end}
+        </p>
+        {quest.image && (
+          <img
+            src={quest.image}
+            alt=""
+            className="mb-4 w-full object-cover rounded"
+          />
+        )}
+        <p className="mb-4 whitespace-pre-line">{quest.description}</p>
+        {quest.url && (
+          <a
+            href={quest.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 underline"
+          >
+            {t('experience_view_more')}
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Experience() {
+  const { t } = useTranslation();
+  const [quests, setQuests] = useState([]);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    fetch('/data/experience.json')
+      .then((res) => res.json())
+      .then((data) => setQuests(data.quests))
+      .catch((err) => console.error('Failed to load quests', err));
+  }, []);
+
+  const mainQuests = quests.filter((q) => q.type === 'main');
+  const sideQuests = quests.filter((q) => q.type === 'side');
+
+  return (
+    <div className="flex-1 p-4 overflow-y-auto">
+      <h1 className="text-3xl mb-6 text-center">{t('experience_title')}</h1>
+
+      <section className="mb-10">
+        <h2 className="text-2xl mb-4">{t('experience_main_quests')}</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {mainQuests.map((quest) => (
+            <QuestCard
+              key={quest.id}
+              quest={quest}
+              onClick={() => setSelected(quest)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-2xl mb-4">{t('experience_side_quests')}</h2>
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {sideQuests.map((quest) => (
+            <QuestCard
+              key={quest.id}
+              quest={quest}
+              onClick={() => setSelected(quest)}
+            />
+          ))}
+        </div>
+      </section>
+
+      {selected && (
+        <QuestModal quest={selected} onClose={() => setSelected(null)} t={t} />
+      )}
+    </div>
+  );
+}

--- a/src/pages/Test.jsx
+++ b/src/pages/Test.jsx
@@ -1,9 +1,7 @@
 import { Home, Loader2, ExternalLink } from 'lucide-react';
 import Button from '../components/Button';
-import { useTranslation } from 'react-i18next';
 
 export default function Test() {
-  const { t } = useTranslation();
 
 
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add experience page listing main and side quests loaded from JSON
- add navigation link, route, and translations for the new page
- fix lint issues in existing components and config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1add86c832192e889a08640396b