### PR TITLE
[site] add experience quest page

### DIFF
--- a/public/quests.json
+++ b/public/quests.json
@@ -1,0 +1,34 @@
+{
+  "mainQuest": {
+    "id": "main",
+    "type": "main",
+    "title": "Forge the Ultimate Portfolio",
+    "description": "Document every experiment and project to craft a living compendium of skills.",
+    "startDate": "2023-01-01",
+    "endDate": null,
+    "url": "https://github.com/Demential98",
+    "image": "https://placekitten.com/400/200"
+  },
+  "sideQuests": [
+    {
+      "id": "diy-nas",
+      "type": "side",
+      "title": "DIY NAS",
+      "description": "Built a network attached storage from spare PC parts and open-source software.",
+      "startDate": "2024-02-01",
+      "endDate": "2024-03-01",
+      "url": "https://github.com/Demential98/diy-nas",
+      "image": "https://placekitten.com/300/200"
+    },
+    {
+      "id": "retro-pi",
+      "type": "side",
+      "title": "RetroPie Arcade",
+      "description": "Configured a Raspberry Pi to emulate classic consoles and built a mini arcade cabinet.",
+      "startDate": "2023-08-15",
+      "endDate": "2023-09-10",
+      "url": "https://github.com/Demential98/retropie-arcade",
+      "image": null
+    }
+  ]
+}

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -9,6 +9,7 @@ import PageWrapper from './components/PageWrapper';
 
 
 import Test from './pages/Test';
+import Experience from './pages/Experience';
 
 export default function AppRoutes() {
   const location = useLocation();
@@ -19,6 +20,7 @@ export default function AppRoutes() {
         <Route path="/" element={<PageWrapper><Home /></PageWrapper>} />
         <Route path="/about" element={<PageWrapper><About /></PageWrapper>} />
         <Route path="/test" element={<PageWrapper><Test /></PageWrapper>} />
+        <Route path="/experience" element={<PageWrapper><Experience /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>
     </AnimatePresence>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,5 +5,10 @@
   "home": "Home",
   "about": "About",
   "not_found_message": "These aren't the droids you're looking for.",
-  "go_home": "Go back home"
+  "go_home": "Go back home",
+  "experience_title": "Quest Log",
+  "experience_loading": "Loading quests...",
+  "experience_present": "Present",
+  "experience_close": "Back",
+  "experience_visit": "Visit"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -5,5 +5,10 @@
   "home": "Home",
   "about": "Informazioni",
   "not_found_message": "Questi non sono i droidi che state cercando",
-  "go_home": "Torna alla home"
+  "go_home": "Torna alla home",
+  "experience_title": "Registro delle missioni",
+  "experience_loading": "Caricamento missioni...",
+  "experience_present": "Presente",
+  "experience_close": "Chiudi",
+  "experience_visit": "Visita"
 }

--- a/src/pages/Experience.jsx
+++ b/src/pages/Experience.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function Experience() {
+  const { t } = useTranslation();
+  const [quests, setQuests] = useState(null);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    fetch('/quests.json')
+      .then((res) => res.json())
+      .then((data) => setQuests([data.mainQuest, ...data.sideQuests]))
+      .catch(() => setQuests([]));
+  }, []);
+
+  if (!quests) {
+    return <div className="p-4">{t('experience_loading')}</div>;
+  }
+
+  return (
+    <div className="p-4 flex flex-col items-center">
+      <h1 className="text-3xl mb-6">{t('experience_title')}</h1>
+      <div className="grid gap-4 w-full max-w-4xl md:grid-cols-2">
+        {quests.map((q) => (
+          <div
+            key={q.id}
+            className={`p-4 border rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 ${q.type === 'main' ? 'border-yellow-500' : 'border-neutral-500'}`}
+            onClick={() => setSelected(q)}
+          >
+            <h2 className="text-xl font-semibold">{q.title}</h2>
+            <p className="text-sm text-neutral-500">
+              {q.startDate} – {q.endDate || t('experience_present')}
+            </p>
+            <p className="mt-2 overflow-hidden text-ellipsis whitespace-nowrap">{q.description}</p>
+          </div>
+        ))}
+      </div>
+
+      {selected && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white dark:bg-neutral-900 p-6 rounded max-w-lg w-full overflow-y-auto max-h-full">
+            <button
+              className="mb-4 text-sm text-right w-full hover:underline"
+              onClick={() => setSelected(null)}
+            >
+              {t('experience_close')}
+            </button>
+            <h2 className="text-2xl font-bold mb-2">{selected.title}</h2>
+            <p className="text-sm text-neutral-500 mb-2">
+              {selected.startDate} – {selected.endDate || t('experience_present')}
+            </p>
+            {selected.image && (
+              <img
+                src={selected.image}
+                alt={selected.title}
+                className="mb-4 rounded w-full object-cover"
+              />
+            )}
+            <p className="mb-4 whitespace-pre-line">{selected.description}</p>
+            {selected.url && (
+              <a
+                className="text-blue-500 hover:underline"
+                href={selected.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('experience_visit')}
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add quest log JSON and experience page
- show details with modal view
- include translations and routing

## Testing
- `npm run lint` *(fails: lastFontSize assigned a value but never used etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1add86c832192e889a08640396b