### PR TITLE
[site] add experience quests page

### DIFF
--- a/public/experience.json
+++ b/public/experience.json
@@ -1,0 +1,28 @@
+{
+  "mainQuest": {
+    "title": "Forge the Ultimate Portfolio",
+    "startDate": "2024-01-01",
+    "endDate": "2024-12-31",
+    "description": "Design and build a personal site showcasing projects, writings and experiments.",
+    "link": "https://github.com/Demential98/Demential98.github.io",
+    "image": "https://placehold.co/600x400/orange/white"
+  },
+  "sideQuests": [
+    {
+      "title": "DIY NAS Build",
+      "startDate": "2023-05-01",
+      "endDate": "2023-06-15",
+      "description": "Assemble a low‑power network attached storage using open‑source tools.",
+      "link": "https://github.com/Demential98/diy-nas",
+      "image": "https://placehold.co/600x400/steelblue/white"
+    },
+    {
+      "title": "React Game Prototype",
+      "startDate": "2023-07-01",
+      "endDate": "2023-08-01",
+      "description": "Experiment with game mechanics in a small browser game built with React.",
+      "link": "https://github.com/Demential98/react-game",
+      "image": ""
+    }
+  ]
+}

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -6,7 +6,7 @@ import Home from './pages/Home';
 import About from './pages/About';
 import NotFound from './pages/NotFound';
 import PageWrapper from './components/PageWrapper';
-
+import Experience from './pages/Experience';
 
 import Test from './pages/Test';
 
@@ -18,6 +18,7 @@ export default function AppRoutes() {
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<PageWrapper><Home /></PageWrapper>} />
         <Route path="/about" element={<PageWrapper><About /></PageWrapper>} />
+        <Route path="/experience" element={<PageWrapper><Experience /></PageWrapper>} />
         <Route path="/test" element={<PageWrapper><Test /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,5 +5,11 @@
   "home": "Home",
   "about": "About",
   "not_found_message": "These aren't the droids you're looking for.",
-  "go_home": "Go back home"
+  "go_home": "Go back home",
+  "experience": "Experience",
+  "main_quest": "Main Quest",
+  "side_quests": "Side Quests",
+  "visit": "Visit",
+  "close": "Close",
+  "loading": "Loading"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -5,5 +5,11 @@
   "home": "Home",
   "about": "Informazioni",
   "not_found_message": "Questi non sono i droidi che state cercando",
-  "go_home": "Torna alla home"
+  "go_home": "Torna alla home",
+  "experience": "Esperienze",
+  "main_quest": "Missione principale",
+  "side_quests": "Missioni secondarie",
+  "visit": "Visita",
+  "close": "Chiudi",
+  "loading": "Caricamento"
 }

--- a/src/pages/Experience.jsx
+++ b/src/pages/Experience.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function QuestCard({ quest, onClick }) {
+  return (
+    <div
+      className="p-4 border rounded shadow-sm cursor-pointer hover:shadow-md transition"
+      onClick={onClick}
+    >
+      <h3 className="text-lg font-semibold">{quest.title}</h3>
+      <p className="text-sm text-neutral-600">
+        {quest.startDate} - {quest.endDate}
+      </p>
+    </div>
+  );
+}
+
+function QuestModal({ quest, onClose }) {
+  const { t } = useTranslation();
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-neutral-800 p-6 rounded max-w-lg w-full overflow-auto max-h-full">
+        <h3 className="text-2xl mb-2">{quest.title}</h3>
+        <p className="text-sm mb-4 text-neutral-600 dark:text-neutral-300">
+          {quest.startDate} - {quest.endDate}
+        </p>
+        {quest.image && (
+          <img
+            src={quest.image}
+            alt={quest.title}
+            className="mb-4 w-full object-cover rounded"
+          />
+        )}
+        <p className="mb-4 whitespace-pre-line">{quest.description}</p>
+        {quest.link && (
+          <a
+            href={quest.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline"
+          >
+            {t('visit')}
+          </a>
+        )}
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-neutral-200 dark:bg-neutral-700 rounded"
+          >
+            {t('close')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Experience() {
+  const { t } = useTranslation();
+  const [data, setData] = useState(null);
+  const [selectedQuest, setSelectedQuest] = useState(null);
+
+  useEffect(() => {
+    fetch('/experience.json')
+      .then((res) => res.json())
+      .then(setData)
+      .catch((err) => console.error('Failed to load experience', err));
+  }, []);
+
+  if (!data) {
+    return <div className="p-4">{t('loading')}...</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-8">
+      <h1 className="text-3xl">{t('experience')}</h1>
+
+      <section>
+        <h2 className="text-xl mb-2">{t('main_quest')}</h2>
+        <QuestCard quest={data.mainQuest} onClick={() => setSelectedQuest(data.mainQuest)} />
+      </section>
+
+      <section>
+        <h2 className="text-xl mb-2">{t('side_quests')}</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          {data.sideQuests.map((quest) => (
+            <QuestCard key={quest.title} quest={quest} onClick={() => setSelectedQuest(quest)} />
+          ))}
+        </div>
+      </section>
+
+      {selectedQuest && (
+        <QuestModal quest={selectedQuest} onClose={() => setSelectedQuest(null)} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add experience page showing main quest and side quests
- load quest data from external JSON and support detail view
- add translations and route for experience page

## Testing
- `npm run lint` (fails: 'textAlign' unused etc.)
- `npx eslint src/pages/Experience.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1add86c832192e889a08640396b