### PR TITLE
[site] add experience navigation and quest timeline

### DIFF
--- a/public/quests.json
+++ b/public/quests.json
@@ -1,18 +1,19 @@
 {
-  "mainQuest": {
-    "id": "main",
-    "type": "main",
-    "title": "Forge the Ultimate Portfolio",
-    "description": "Document every experiment and project to craft a living compendium of skills.",
-    "startDate": "2023-01-01",
-    "endDate": null,
-    "url": "https://github.com/Demential98",
-    "image": "https://placekitten.com/400/200"
-  },
-  "sideQuests": [
+  "quests": [
+    {
+      "id": "main1",
+      "type": "main",
+      "title": "Forge the Ultimate Portfolio",
+      "description": "Document every experiment and project to craft a living compendium of skills.",
+      "startDate": "2023-01-01",
+      "endDate": null,
+      "url": "https://github.com/Demential98",
+      "image": "https://placekitten.com/400/200"
+    },
     {
       "id": "diy-nas",
       "type": "side",
+      "father": "main1",
       "title": "DIY NAS",
       "description": "Built a network attached storage from spare PC parts and open-source software.",
       "startDate": "2024-02-01",
@@ -29,6 +30,28 @@
       "endDate": "2023-09-10",
       "url": "https://github.com/Demential98/retropie-arcade",
       "image": null
+    },
+    {
+      "id": "main2",
+      "type": "main",
+      "title": "Conquer the Job Market",
+      "description": "Level up interview skills and apply to dream companies.",
+      "startDate": "2024-04-01",
+      "endDate": null,
+      "url": "https://linkedin.com/in/",
+      "image": "https://placekitten.com/401/200"
+    },
+    {
+      "id": "k8s-lab",
+      "type": "side",
+      "father": "main2",
+      "title": "Kubernetes Lab",
+      "description": "Experimented with container orchestration using K8s and Helm charts.",
+      "startDate": "2024-05-01",
+      "endDate": null,
+      "url": "https://github.com/Demential98/k8s-lab",
+      "image": null
     }
   ]
 }
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,8 +135,24 @@ function App() {
               speed="5s"
             >
               <Link to="/about" >
-                <ShinyText 
+                <ShinyText
                   text={t('about')}
+                  disabled={false}
+                  speed={3}
+                  className='custom-class'
+                />
+                </Link>
+            </StarBorder>
+            <StarBorder
+              as="div"
+              className="custom-class"
+              color={theme === 'dark' ? 'cyan' : '#020617'}
+              thickness="2"
+              speed="5s"
+            >
+              <Link to="/experience" >
+                <ShinyText
+                  text={t('experience')}
                   disabled={false}
                   speed={3}
                   className='custom-class'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
   "light_mode": "Switch to Light Mode",
   "home": "Home",
   "about": "About",
+  "experience": "Experience",
   "not_found_message": "These aren't the droids you're looking for.",
   "go_home": "Go back home",
   "experience_title": "Quest Log",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -4,6 +4,7 @@
   "light_mode": "Passa alla modalità chiara",
   "home": "Home",
   "about": "Informazioni",
+  "experience": "Esperienze",
   "not_found_message": "Questi non sono i droidi che state cercando",
   "go_home": "Torna alla home",
   "experience_title": "Registro delle missioni",

--- a/src/pages/Experience.jsx
+++ b/src/pages/Experience.jsx
@@ -1,39 +1,143 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+function buildQuestTree(list) {
+  const map = {};
+  list.forEach((q) => {
+    map[q.id] = { ...q, children: [] };
+  });
+  const roots = [];
+  list.forEach((q) => {
+    if (q.father && map[q.father]) {
+      map[q.father].children.push(map[q.id]);
+    } else {
+      roots.push(map[q.id]);
+    }
+  });
+  return roots;
+}
+
+function QuestCard({ quest, onSelect, presentText }) {
+  return (
+    <div
+      className={`p-4 border rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 ${quest.type === 'main' ? 'border-yellow-500' : 'border-neutral-500'}`}
+      onClick={() => onSelect(quest)}
+    >
+      <h2 className="text-xl font-semibold">{quest.title}</h2>
+      <p className="text-sm text-neutral-500">
+        {quest.startDate} – {quest.endDate || presentText}
+      </p>
+      <p className="mt-2 overflow-hidden text-ellipsis whitespace-nowrap">{quest.description}</p>
+    </div>
+  );
+}
+
+function MainQuestItem({ quest, index, onSelect, presentText }) {
+  const side = index % 2 === 0 ? 'left' : 'right';
+  return (
+    <div className="relative flex items-start">
+      {side === 'left' && (
+        <>
+          <div className="w-1/2 pr-8 flex flex-col items-end">
+            <QuestCard quest={quest} onSelect={onSelect} presentText={presentText} />
+            {quest.children.length > 0 && (
+              <div className="mt-4 space-y-4 border-r-2 border-neutral-500 pr-4">
+                {quest.children.map((child) => (
+                  <QuestCard
+                    key={child.id}
+                    quest={child}
+                    onSelect={onSelect}
+                    presentText={presentText}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="w-1/2" />
+        </>
+      )}
+      {side === 'right' && (
+        <>
+          <div className="w-1/2" />
+          <div className="w-1/2 pl-8 flex flex-col items-start">
+            <QuestCard quest={quest} onSelect={onSelect} presentText={presentText} />
+            {quest.children.length > 0 && (
+              <div className="mt-4 space-y-4 border-l-2 border-neutral-500 pl-4">
+                {quest.children.map((child) => (
+                  <QuestCard
+                    key={child.id}
+                    quest={child}
+                    onSelect={onSelect}
+                    presentText={presentText}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+      <div className="absolute left-1/2 top-6 -translate-x-1/2 w-3 h-3 rounded-full bg-yellow-500" />
+      <div
+        className={`absolute top-7 h-px w-8 bg-yellow-500 ${
+          side === 'left' ? 'left-1/2 -translate-x-full' : 'left-1/2'
+        }`}
+      />
+    </div>
+  );
+}
+
 export default function Experience() {
   const { t } = useTranslation();
-  const [quests, setQuests] = useState(null);
+  const [roots, setRoots] = useState(null);
   const [selected, setSelected] = useState(null);
 
   useEffect(() => {
     fetch('/quests.json')
       .then((res) => res.json())
-      .then((data) => setQuests([data.mainQuest, ...data.sideQuests]))
-      .catch(() => setQuests([]));
+      .then((data) => setRoots(buildQuestTree(data.quests)))
+      .catch(() => setRoots([]));
   }, []);
 
-  if (!quests) {
+  if (!roots) {
     return <div className="p-4">{t('experience_loading')}</div>;
   }
+
+  const mainRoots = roots.filter((q) => q.type === 'main');
+  const otherRoots = roots.filter((q) => q.type !== 'main');
+
+  mainRoots.sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
 
   return (
     <div className="p-4 flex flex-col items-center">
       <h1 className="text-3xl mb-6">{t('experience_title')}</h1>
-      <div className="grid gap-4 w-full max-w-4xl md:grid-cols-2">
-        {quests.map((q) => (
-          <div
-            key={q.id}
-            className={`p-4 border rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 ${q.type === 'main' ? 'border-yellow-500' : 'border-neutral-500'}`}
-            onClick={() => setSelected(q)}
-          >
-            <h2 className="text-xl font-semibold">{q.title}</h2>
-            <p className="text-sm text-neutral-500">
-              {q.startDate} – {q.endDate || t('experience_present')}
-            </p>
-            <p className="mt-2 overflow-hidden text-ellipsis whitespace-nowrap">{q.description}</p>
+      <div className="w-full max-w-4xl space-y-8">
+        <div className="relative">
+          <div className="absolute left-1/2 top-0 bottom-0 w-px bg-yellow-500" />
+          <div className="space-y-12">
+            {mainRoots.map((q, idx) => (
+              <MainQuestItem
+                key={q.id}
+                quest={q}
+                index={idx}
+                onSelect={setSelected}
+                presentText={t('experience_present')}
+              />
+            ))}
           </div>
-        ))}
+        </div>
+
+        {otherRoots.length > 0 && (
+          <div className="space-y-4">
+            {otherRoots.map((q) => (
+              <QuestCard
+                key={q.id}
+                quest={q}
+                onSelect={setSelected}
+                presentText={t('experience_present')}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       {selected && (
@@ -73,3 +177,5 @@ export default function Experience() {
     </div>
   );
 }
+
+


### PR DESCRIPTION
## Summary
- add header link for Experience page
- support quest tree with multiple main quests and parent links
- revamp Experience page into centered timeline with branching side quests

## Testing
- `npm run lint` *(fails: no-unused-vars, no-undef in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a10fe64bb8832191472bdd5c671e49