### PR TITLE
[site] Add interactive experience graph

### DIFF
--- a/public/pages.json
+++ b/public/pages.json
@@ -1,0 +1,22 @@
+{
+  "pages": [
+    {
+      "id": "home",
+      "title": "Home",
+      "content": "Landing page overview.",
+      "links": ["about", "experience"]
+    },
+    {
+      "id": "about",
+      "title": "About",
+      "content": "Information about me.",
+      "links": ["experience"]
+    },
+    {
+      "id": "experience",
+      "title": "Experience",
+      "content": "My quest log.",
+      "links": ["home", "about"]
+    }
+  ]
+}

--- a/src/components/FuzzyText.jsx
+++ b/src/components/FuzzyText.jsx
@@ -23,8 +23,6 @@ const FuzzyText = ({
   const canvas = canvasRef.current;
   if (!canvas) return;
 
-  let lastColor = "";
-  let lastFontSize = "";
 
   const drawText = async () => {
     if (document.fonts?.ready) await document.fonts.ready;
@@ -183,8 +181,6 @@ const FuzzyText = ({
     };
 
     canvas.cleanupFuzzyText = cleanup;
-    lastColor = resolvedColor;
-    lastFontSize = fontSizeStr;
   };
 
   drawText();

--- a/src/components/SplitText/SplitText.jsx
+++ b/src/components/SplitText/SplitText.jsx
@@ -6,7 +6,6 @@ const SplitText = ({
   className = '',
   delay = 0.05,
   triggerOnScroll = true,
-  textAlign = 'left',
 }) => {
   const containerRef = useRef(null);
   const [active, setActive] = useState(!triggerOnScroll);

--- a/src/components/StarBorder/StarBorder.jsx
+++ b/src/components/StarBorder/StarBorder.jsx
@@ -1,7 +1,7 @@
 import "./StarBorder.css";
 
 const StarBorder = ({
-  as: Component = "button",
+  as = "button",
   className = "",
   color = "white",
   speed = "6s",
@@ -9,9 +9,10 @@ const StarBorder = ({
   children,
   ...rest
 }) => {
+  const Component = as;
   return (
-    <Component 
-      className={`star-border-container ${className}`} 
+    <Component
+      className={`star-border-container ${className}`}
       style={{
         padding: `${thickness}px 0`,
         ...rest.style

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,5 +11,6 @@
   "experience_loading": "Loading quests...",
   "experience_present": "Present",
   "experience_close": "Back",
-  "experience_visit": "Visit"
+  "experience_visit": "Visit",
+  "experience_pages": "Pages"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -11,5 +11,6 @@
   "experience_loading": "Caricamento missioni...",
   "experience_present": "Presente",
   "experience_close": "Chiudi",
-  "experience_visit": "Visita"
+  "experience_visit": "Visita",
+  "experience_pages": "Pagine"
 }

--- a/src/pages/Experience.jsx
+++ b/src/pages/Experience.jsx
@@ -1,41 +1,112 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export default function Experience() {
   const { t } = useTranslation();
-  const [quests, setQuests] = useState(null);
+  const [pages, setPages] = useState(null);
   const [selected, setSelected] = useState(null);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const dragRef = useRef(null);
 
   useEffect(() => {
-    fetch('/quests.json')
+    fetch('/pages.json')
       .then((res) => res.json())
-      .then((data) => setQuests([data.mainQuest, ...data.sideQuests]))
-      .catch(() => setQuests([]));
+      .then((data) => {
+        const radius = 200;
+        const nodes = data.pages.map((p, i) => {
+          const angle = (2 * Math.PI * i) / data.pages.length;
+          return { ...p, x: radius * Math.cos(angle), y: radius * Math.sin(angle) };
+        });
+        setPages(nodes);
+      })
+      .catch(() => setPages([]));
   }, []);
 
-  if (!quests) {
+  const edges =
+    pages?.flatMap((p) => p.links.map((l) => ({ from: p.id, to: l }))) || [];
+
+  const handleMouseDown = (e) => {
+    dragRef.current = { x: e.clientX - offset.x, y: e.clientY - offset.y };
+  };
+
+  const handleMouseMove = (e) => {
+    if (!dragRef.current) return;
+    setOffset({ x: e.clientX - dragRef.current.x, y: e.clientY - dragRef.current.y });
+  };
+
+  const handleMouseUp = () => {
+    dragRef.current = null;
+  };
+
+  if (!pages) {
     return <div className="p-4">{t('experience_loading')}</div>;
   }
 
   return (
-    <div className="p-4 flex flex-col items-center">
-      <h1 className="text-3xl mb-6">{t('experience_title')}</h1>
-      <div className="grid gap-4 w-full max-w-4xl md:grid-cols-2">
-        {quests.map((q) => (
+    <div className="flex h-full">
+      <aside className="w-48 p-4 border-r overflow-y-auto">
+        <h2 className="font-bold mb-2">{t('experience_pages')}</h2>
+        <ul className="space-y-1">
+          {pages.map((p) => (
+            <li key={p.id}>
+              <button
+                className="text-left hover:underline"
+                onClick={() => setSelected(p)}
+              >
+                {p.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <div
+        className="flex-1 relative overflow-hidden"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        <svg
+          className="absolute inset-0"
+          width="100%"
+          height="100%"
+          style={{
+            cursor: dragRef.current ? 'grabbing' : 'grab',
+            transform: `translate(${offset.x}px, ${offset.y}px)`
+          }}
+          viewBox="-250 -250 500 500"
+        >
+          {edges.map((e, i) => {
+            const a = pages.find((p) => p.id === e.from);
+            const b = pages.find((p) => p.id === e.to);
+            if (!a || !b) return null;
+            return (
+              <line
+                key={i}
+                x1={a.x}
+                y1={a.y}
+                x2={b.x}
+                y2={b.y}
+                className="stroke-neutral-500"
+              />
+            );
+          })}
+          {pages.map((p) => (
+            <g key={p.id} onClick={() => setSelected(p)} className="cursor-pointer">
+              <circle cx={p.x} cy={p.y} r="20" className="fill-yellow-400" />
+            </g>
+          ))}
+        </svg>
+        {pages.map((p) => (
           <div
-            key={q.id}
-            className={`p-4 border rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 ${q.type === 'main' ? 'border-yellow-500' : 'border-neutral-500'}`}
-            onClick={() => setSelected(q)}
+            key={p.id}
+            style={{ left: p.x + offset.x + 250, top: p.y + offset.y + 250 }}
+            className="absolute text-center text-xs pointer-events-none"
           >
-            <h2 className="text-xl font-semibold">{q.title}</h2>
-            <p className="text-sm text-neutral-500">
-              {q.startDate} – {q.endDate || t('experience_present')}
-            </p>
-            <p className="mt-2 overflow-hidden text-ellipsis whitespace-nowrap">{q.description}</p>
+            {p.title}
           </div>
         ))}
       </div>
-
       {selected && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="bg-white dark:bg-neutral-900 p-6 rounded max-w-lg w-full overflow-y-auto max-h-full">
@@ -46,27 +117,7 @@ export default function Experience() {
               {t('experience_close')}
             </button>
             <h2 className="text-2xl font-bold mb-2">{selected.title}</h2>
-            <p className="text-sm text-neutral-500 mb-2">
-              {selected.startDate} – {selected.endDate || t('experience_present')}
-            </p>
-            {selected.image && (
-              <img
-                src={selected.image}
-                alt={selected.title}
-                className="mb-4 rounded w-full object-cover"
-              />
-            )}
-            <p className="mb-4 whitespace-pre-line">{selected.description}</p>
-            {selected.url && (
-              <a
-                className="text-blue-500 hover:underline"
-                href={selected.url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {t('experience_visit')}
-              </a>
-            )}
+            <p className="mb-4 whitespace-pre-line">{selected.content}</p>
           </div>
         </div>
       )}

--- a/src/pages/Test.jsx
+++ b/src/pages/Test.jsx
@@ -1,27 +1,23 @@
 import { Home, Loader2, ExternalLink } from 'lucide-react';
 import Button from '../components/Button';
-import { useTranslation } from 'react-i18next';
 
 export default function Test() {
-  const { t } = useTranslation();
+  return (
+    <>
+      {/* With start icon */}
+      <Button to='/' iconStart={<Home size={18} />} variant='primary'>
+        Home
+      </Button>
 
+      {/* With end icon */}
+      <Button href='/docs' iconEnd={<ExternalLink size={16} />} variant='outline'>
+        Docs
+      </Button>
 
-
-return (<>
-// With start icon
-<Button to="/" iconStart={<Home size={18} />} variant="primary">
-  Home
-</Button>
-
-// With end icon
-<Button href="/docs" iconEnd={<ExternalLink size={16} />} variant="outline">
-  Docs
-</Button>
-
-// Loading state
-<Button loading variant="primary">
-  Loading...
-</Button>
-</>
-);
+      {/* Loading state */}
+      <Button loading variant='primary'>
+        Loading...
+      </Button>
+    </>
+  );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- display pages as draggable nodes linked by lines on the Experience page
- list page titles in a left sidebar and open details on selection
- fix lint issues across components and add JSON source for page graph

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2fdd9c7508321869269b1b1048a5f